### PR TITLE
add rememberNavigationResultNavEntryDecorator() overload

### DIFF
--- a/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultNavEntryDecorator.kt
+++ b/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultNavEntryDecorator.kt
@@ -2,7 +2,12 @@ package io.github.irgaly.navigation3.resultstate
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavEntryDecorator
 import androidx.navigation3.runtime.navEntryDecorator
 
@@ -37,6 +42,34 @@ fun <T: Any> NavigationResultNavEntryDecorator(
 fun <T: Any> rememberNavigationResultNavEntryDecorator(
     navigationResultStateHolder: NavigationResultStateHolder<T>,
 ): NavEntryDecorator<Any> {
+    return remember(navigationResultStateHolder) {
+        NavigationResultNavEntryDecorator(navigationResultStateHolder)
+    }
+}
+
+/**
+ * remember [NavigationResultStateHolder]
+ * and then, remember [NavigationResultNavEntryDecorator]
+ *
+ * @param entryProvider the same entryProvider lambda as it is specified to AppNavHost
+ * @param contentKeyToString lambda to convert NavEntry.contentKey to String for serialization for SavedState
+ * @see [rememberNavigationResultStateHolder]
+ */
+@Composable
+fun <T : Any> rememberNavigationResultNavEntryDecorator(
+    navBackStack: SnapshotStateList<T>,
+    entryProvider: (T) -> NavEntry<*>,
+    contentKeyToString: (Any) -> String = { it.toString() },
+    savedStateResults: MutableState<Map<String, Map<String, String>>> = rememberSaveable {
+        mutableStateOf(emptyMap())
+    },
+): NavEntryDecorator<Any> {
+    val navigationResultStateHolder = rememberNavigationResultStateHolder(
+        navBackStack = navBackStack,
+        entryProvider = entryProvider,
+        contentKeyToString = contentKeyToString,
+        savedStateResults = savedStateResults,
+    )
     return remember(navigationResultStateHolder) {
         NavigationResultNavEntryDecorator(navigationResultStateHolder)
     }

--- a/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultNavEntryDecorator.kt
+++ b/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultNavEntryDecorator.kt
@@ -17,7 +17,7 @@ import androidx.navigation3.runtime.navEntryDecorator
 @Suppress("FunctionName")
 fun <T: Any> NavigationResultNavEntryDecorator(
     navigationResultStateHolder: NavigationResultStateHolder<T>,
-): NavEntryDecorator<Any> {
+): NavEntryDecorator<T> {
     return navEntryDecorator(
         onPop = { contentKey ->
             navigationResultStateHolder.onPop(contentKey)
@@ -41,7 +41,7 @@ fun <T: Any> NavigationResultNavEntryDecorator(
 @Composable
 fun <T: Any> rememberNavigationResultNavEntryDecorator(
     navigationResultStateHolder: NavigationResultStateHolder<T>,
-): NavEntryDecorator<Any> {
+): NavEntryDecorator<T> {
     return remember(navigationResultStateHolder) {
         NavigationResultNavEntryDecorator(navigationResultStateHolder)
     }
@@ -63,7 +63,7 @@ fun <T : Any> rememberNavigationResultNavEntryDecorator(
     savedStateResults: MutableState<Map<String, Map<String, String>>> = rememberSaveable {
         mutableStateOf(emptyMap())
     },
-): NavEntryDecorator<Any> {
+): NavEntryDecorator<T> {
     val navigationResultStateHolder = rememberNavigationResultStateHolder(
         navBackStack = navBackStack,
         entryProvider = entryProvider,

--- a/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultStateHolder.kt
+++ b/resultstate/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/NavigationResultStateHolder.kt
@@ -153,7 +153,7 @@ class NavigationResultStateHolder <T: Any>(
 }
 
 /**
- * create and remember NavigationResultStateHolder
+ * create and remember [NavigationResultStateHolder]
  *
  * @param entryProvider the same entryProvider lambda as it is specified to AppNavHost
  * @param contentKeyToString lambda to convert NavEntry.contentKey to String for serialization for SavedState

--- a/sample/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/sample/App.kt
+++ b/sample/src/commonMain/kotlin/io/github/irgaly/navigation3/resultstate/sample/App.kt
@@ -16,7 +16,6 @@ import androidx.savedstate.compose.serialization.serializers.SnapshotStateListSe
 import androidx.savedstate.serialization.SavedStateConfiguration
 import io.github.irgaly.navigation3.resultstate.NavigationResultMetadata
 import io.github.irgaly.navigation3.resultstate.rememberNavigationResultNavEntryDecorator
-import io.github.irgaly.navigation3.resultstate.rememberNavigationResultStateHolder
 import io.github.irgaly.navigation3.resultstate.resultConsumer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -91,10 +90,6 @@ fun App() {
                 )
             }
         }
-        val navigationResultStateHolder = rememberNavigationResultStateHolder(
-            navBackStack = navBackStack,
-            entryProvider = entryProvider,
-        )
         NavDisplay(
             backStack = navBackStack,
             onBack = {
@@ -104,7 +99,10 @@ fun App() {
             },
             entryDecorators = listOf(
                 rememberSceneSetupNavEntryDecorator(),
-                rememberNavigationResultNavEntryDecorator(navigationResultStateHolder),
+                rememberNavigationResultNavEntryDecorator(
+                    navBackStack = navBackStack,
+                    entryProvider = entryProvider,
+                ),
                 rememberSavedStateNavEntryDecorator(),
             ),
             entryProvider = entryProvider,


### PR DESCRIPTION
NavigationResultStateHolderを生成せずに、以下のように書けるようになる。

```kotlin
        NavDisplay(
            backStack = navBackStack,
            onBack = {
                if (navBackStack.isNotEmpty()) {
                    navBackStack.removeLastOrNull()
                }
            },
            entryDecorators = listOf(
                rememberSceneSetupNavEntryDecorator(),
                rememberNavigationResultNavEntryDecorator(
                    navBackStack = navBackStack,
                    entryProvider = entryProvider,
                ),
                rememberSavedStateNavEntryDecorator(),
            ),
            entryProvider = entryProvider,
        )
```